### PR TITLE
turn off react method-ordering rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
     "react/jsx-key": 2,
     "react/no-array-index-key": 1,
     "react/require-default-props": 0,
+    "react/sort-comp": 0,
     "space-before-function-paren": 0
   },
   settings: {


### PR DESCRIPTION
This PR turns off the react/sort-comp rule (forces certain ordering of methods)