### PR TITLE
Adding in eslint rule to prefer React.Fragment over the fragment shorthand.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
     "object-curly-newline": 1,
     "object-property-newline": ["error", { "allowAllPropertiesOnSameLine": true }],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "react/jsx-fragments": [1, "element"],
     "react/jsx-key": 2,
     "react/no-array-index-key": 1,
     "react/require-default-props": 0,

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
     "object-curly-newline": 1,
     "object-property-newline": ["error", { "allowAllPropertiesOnSameLine": true }],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "react/jsx-fragments": [1, "element"],
+    "react/jsx-fragments": [2, "element"],
     "react/jsx-key": 2,
     "react/no-array-index-key": 1,
     "react/require-default-props": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-curology",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shareable ESLint config for Curology",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Based off the discussion in Demo/Discussion:

https://www.notion.so/curology/Using-React-Fragment-vs-fca496a374f040798bd75ffd3ac26eb2

We're adding in a rule to enforce the longer form:

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md