### PR TITLE
Update rule react/require-default-props to error instead of ignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     "react/jsx-fragments": [2, "element"],
     "react/jsx-key": 2,
     "react/no-array-index-key": 1,
-    "react/require-default-props": 0,
+    "react/require-default-props": 2,
     "react/sort-comp": 0,
     "space-before-function-paren": 0
   },


### PR DESCRIPTION
This PR updates the rule `react/require-default-props` to error instead of ignoring the rule. This will require stricter documentation of `prop-types` in components that have them. I had considered making the rule warn instead of error, but I think the friction of erroring is minimal compared to the benefit of making our `.js` files more ready for `.ts` conversion. 

Upon implementing this update, I will provide the team with an announcement about the stricter enforcement and what to expect. 