### PR TITLE
Turn import/prefer-default-export off

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     "import/extensions": ["error", "never"],
     "import/no-unresolved": 0,
     "import/order": [2, {"groups": [["builtin", "external"], "internal", ["parent", "sibling"]], "newlines-between": "always"}],
-    "import/prefer-default-export": 1,
+    "import/prefer-default-export": 0,
     "import/no-extraneous-dependencies": [2, { "devDependencies": true }],
     "indent": ["error", 2, { "SwitchCase": 1 }],
     "jsx-a11y/anchor-is-valid": 1,


### PR DESCRIPTION
This PR updates our rule for `import/prefer-default-export` from warning to off, owing to patterns that prefer using named exports, even for files with only one export.