### PR TITLE
V2 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ by adding this to your `.eslintrc` file:
 
 ```
 {
-  "extends": ["curology", ...otherConfig, "prettier"]
+  "extends": [...otherConfig, "curology"]
 }
 ```
 
-`"prettier"` must be the last entry in "extends" for [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) compatibility
+`"curology"` must be the last entry in "extends" for [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier/blob/1f206661b8e197e6753b772509028c34f954b42a/README.md#recommended-configuration) compatibility

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 module.exports = {
   extends: [
     "airbnb",
-    "plugin:prettier/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["curology"],
   rules: {
-    "arrow-body-style": [2, "as-needed"],
     "arrow-parens": [2, "as-needed"],
     "class-methods-use-this": 0,
     "comma-dangle": [2, "always-multiline"],

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["curology"],
   rules: {
+    "@typescript-eslint/prefer-ts-expect-error": 2,
     "arrow-parens": [2, "as-needed"],
     "class-methods-use-this": 0,
     "comma-dangle": [2, "always-multiline"],


### PR DESCRIPTION
- Re-order config extensions
- Add `@typescript-eslint/prefer-ts-expect-error` as error. 
- Remove `arrow-body-style` (handled by `prettier` config). 