### PR TITLE
Deprecate Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 3.0.0
+
+- **This package is no longer maintained**. All existing configuration options can now be found in `eslint-plugin-curology`. 
+
 # 2.2.0
 
 - Ignore `react/jsx-one-expression-per-line`, `react/jsx-wrap-multilines`, `object-curly-newline`, and `indent`.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
 # eslint-config-curology
 
-An ESLint [Shareable Config](https://eslint.org/docs/developer-guide/shareable-configs)
-for use at [Curology](https://curology.com/).
-
-## Install
-
-Run
-
-```
-yarn add eslint-config-curology --dev
-```
-
-## Usage
-
-Assuming you already have ESLint configured, extend this configuration
-by adding this to your `.eslintrc` file:
-
-```
-{
-  "extends": [...otherConfig, "curology"]
-}
-```
-
-`"curology"` must be the last entry in "extends" for [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier/blob/1f206661b8e197e6753b772509028c34f954b42a/README.md#recommended-configuration) compatibility
+**This package is deprecated**. All future usage should pull in `eslint-plugin-curology`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-curology",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Shareable ESLint config for Curology",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions

We are going to combine config and plugin in `eslint-plugin-curology` so that we do not have two separate dependencies.